### PR TITLE
Fix resume link path

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -34,7 +34,7 @@
 <h1>Profile</h1>
 <div class="content">
     <p>Hello! I’m Siyuan. Here you can find more about my work and background.</p>
-    <a href="siyuan.github.io/Siyuan_cv.pdf" class="resume-link" target="_blank">Download My Resume</a>
+    <a href="Siyuan_cv.pdf" class="resume-link" target="_blank">Download My Resume</a>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary
- update resume link on the profile page to correctly reference the PDF

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68403e04e998832eacc35ed83a715290